### PR TITLE
feat: add configurable directory exclusion for file size tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Compatible with VS Code and Cursor.
 - Hover over files to see human-readable file sizes in tooltips
 - Displays the size of the currently active file in the status bar
 
+## Notes
+
+The ⓘ symbol is displayed when file sizes cannot be represented in exactly 2 characters (the limitation of VS Code badges). In these cases, hover over the file to see the full human-readable file size in the tooltip.
+
+## Configuration
+
+### `fileSizeBadge.excludedDirectories`
+
+Array of directory names to exclude from file size tracking. This improves performance by reducing unnecessary file system operations.
+
+**Default:** `[".git", "build", "dist", "node_modules"]`
+
+You can customize this list in your VS Code settings to exclude additional directories specific to your project.
+
 ## License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-size-badge",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-size-badge",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "file-size-badge",
   "displayName": "File Size Badge",
   "description": "Displays file sizes as badges in the file explorer and shows the active file size in the status bar.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "silvioprog",
   "license": "MIT",
   "icon": "icon.png",
@@ -25,6 +25,26 @@
   "activationEvents": [
     "onStartupFinished"
   ],
+  "contributes": {
+    "configuration": {
+      "title": "File Size Badge",
+      "properties": {
+        "fileSizeBadge.excludedDirectories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            ".git",
+            "build",
+            "dist",
+            "node_modules"
+          ],
+          "description": "Directories to exclude from file size tracking. This improves performance by reducing unnecessary file system operations."
+        }
+      }
+    }
+  },
   "main": "./dist/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -31,6 +31,16 @@ export const workspace = {
     onDidDelete: jest.fn(),
     onDidChange: jest.fn(),
     dispose: jest.fn()
+  })),
+  getConfiguration: jest.fn((section?: string) => ({
+    get: jest.fn((key: string, defaultValue?: unknown) => {
+      if (section === "fileSizeBadge") {
+        if (key === "excludedDirectories") {
+          return defaultValue || [".git", "build", "dist", "node_modules"];
+        }
+      }
+      return defaultValue;
+    })
   }))
 };
 

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -1,8 +1,36 @@
 import * as vscode from "vscode";
 import { updateDecorations } from "./eventEmitter";
 
+const getExcludedDirs = () =>
+  vscode.workspace
+    .getConfiguration("fileSizeBadge")
+    .get<string[]>("excludedDirectories", []);
+
+const shouldExclude = (fsPath: string) => {
+  const normalizedPath = fsPath.replace(/\\/g, "/");
+
+  return getExcludedDirs().some(
+    (dir) =>
+      normalizedPath.includes(`/${dir}/`) || normalizedPath.endsWith(`/${dir}`)
+  );
+};
+
 export const fileWatcher = vscode.workspace.createFileSystemWatcher("**/*");
 
-fileWatcher.onDidCreate(updateDecorations);
-fileWatcher.onDidDelete(updateDecorations);
-fileWatcher.onDidChange(updateDecorations);
+fileWatcher.onDidCreate((uri) => {
+  if (!shouldExclude(uri.fsPath)) {
+    updateDecorations(uri);
+  }
+});
+
+fileWatcher.onDidDelete((uri) => {
+  if (!shouldExclude(uri.fsPath)) {
+    updateDecorations(uri);
+  }
+});
+
+fileWatcher.onDidChange((uri) => {
+  if (!shouldExclude(uri.fsPath)) {
+    updateDecorations(uri);
+  }
+});


### PR DESCRIPTION
Adds support for excluding directories from file size tracking to improve performance in large projects.

- Introduces `fileSizeBadge.excludedDirectories` configuration option
- Default excludes: `.git`, `build`, `dist`, `node_modules`
- File watcher now skips excluded directories
- Updates documentation with configuration details

Closes #2