### PR TITLE
feat: add configurable status bar alignment and priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compatible with VS Code and Cursor.
 
 ## Notes
 
-The ⓘ symbol is displayed when file sizes cannot be represented in exactly 2 characters (the limitation of VS Code badges). In these cases, hover over the file to see the full human-readable file size in the tooltip.
+The ⓘ symbol is displayed when file sizes cannot be represented in exactly 2 characters (the limitation of IDE badges). In these cases, hover over the file to see the full human-readable file size in the tooltip.
 
 ## Configuration
 
@@ -24,7 +24,19 @@ Array of directory names to exclude from file size tracking. This improves perfo
 
 **Default:** `[".git", "build", "dist", "node_modules"]`
 
-You can customize this list in your VS Code settings to exclude additional directories specific to your project.
+You can customize this list in your IDE settings to exclude additional directories specific to your project.
+
+### `fileSizeBadge.statusBarAlignment`
+
+Alignment of the status bar item. Choose `"Left"` to place it on the left side of the status bar, or `"Right"` to place it on the right side.
+
+**Default:** `"Left"`
+
+### `fileSizeBadge.statusBarPriority`
+
+Priority for the status bar item. Lower numbers appear more to the left. Leave empty to let IDE decide the priority automatically.
+
+**Default:** `null`
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-size-badge",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-size-badge",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "file-size-badge",
   "displayName": "File Size Badge",
   "description": "Displays file sizes as badges in the file explorer and shows the active file size in the status bar.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "silvioprog",
   "license": "MIT",
   "icon": "icon.png",
@@ -41,6 +41,23 @@
             "node_modules"
           ],
           "description": "Directories to exclude from file size tracking. This improves performance by reducing unnecessary file system operations."
+        },
+        "fileSizeBadge.statusBarAlignment": {
+          "type": "string",
+          "enum": [
+            "Left",
+            "Right"
+          ],
+          "default": "Left",
+          "description": "Alignment of the status bar item. 'Left' places it on the left side, 'Right' on the right side."
+        },
+        "fileSizeBadge.statusBarPriority": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": null,
+          "description": "Priority for the status bar item. Lower numbers appear more to the left. Leave empty to let IDE decide the position automatically."
         }
       }
     }

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -14,18 +14,15 @@ export const window = {
     show: jest.fn(),
     hide: jest.fn()
   })),
-  onDidChangeActiveTextEditor: jest.fn(() => ({
+  registerFileDecorationProvider: jest.fn(() => ({
     dispose: jest.fn()
   })),
-  registerFileDecorationProvider: jest.fn(() => ({
+  onDidChangeActiveTextEditor: jest.fn(() => ({
     dispose: jest.fn()
   }))
 };
 
 export const workspace = {
-  onDidSaveTextDocument: jest.fn(() => ({
-    dispose: jest.fn()
-  })),
   createFileSystemWatcher: jest.fn(() => ({
     onDidCreate: jest.fn(),
     onDidDelete: jest.fn(),
@@ -38,9 +35,21 @@ export const workspace = {
         if (key === "excludedDirectories") {
           return defaultValue || [".git", "build", "dist", "node_modules"];
         }
+        if (key === "statusBarPriority") {
+          return defaultValue !== undefined ? defaultValue : null;
+        }
+        if (key === "statusBarAlignment") {
+          return defaultValue !== undefined ? defaultValue : "Left";
+        }
       }
       return defaultValue;
     })
+  })),
+  onDidSaveTextDocument: jest.fn(() => ({
+    dispose: jest.fn()
+  })),
+  onDidChangeConfiguration: jest.fn(() => ({
+    dispose: jest.fn()
   }))
 };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,14 @@
 import * as vscode from "vscode";
+import { provider } from "./provider";
 import { eventEmitter, updateDecorations } from "./eventEmitter";
 import { fileWatcher } from "./fileWatcher";
-import { provider } from "./provider";
 import {
   statusBar,
   updateStatusBar,
   updateStatusBarOnChangeActiveTextEditor,
   updateStatusBarOnChangeTabs,
-  updateStatusBarOnSaveTextDocument
+  updateStatusBarOnSaveTextDocument,
+  updateStatusBarOnChangeConfiguration
 } from "./statusBar";
 
 vscode.workspace.onDidChangeWorkspaceFolders(() => updateDecorations());
@@ -21,6 +22,11 @@ vscode.workspace.onDidRenameFiles(({ files }) =>
 );
 vscode.workspace.onDidSaveTextDocument(({ uri }) => updateDecorations(uri));
 vscode.workspace.onDidOpenTextDocument(({ uri }) => updateDecorations(uri));
+vscode.workspace.onDidChangeConfiguration((e) => {
+  if (e.affectsConfiguration("fileSizeBadge")) {
+    updateDecorations();
+  }
+});
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
   subscriptions.push(
@@ -30,7 +36,8 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
     statusBar,
     updateStatusBarOnChangeActiveTextEditor,
     updateStatusBarOnChangeTabs,
-    updateStatusBarOnSaveTextDocument
+    updateStatusBarOnSaveTextDocument,
+    updateStatusBarOnChangeConfiguration
   );
   updateStatusBar();
 }

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -6,7 +6,7 @@ const getExcludedDirs = () =>
     .getConfiguration("fileSizeBadge")
     .get<string[]>("excludedDirectories", []);
 
-const shouldExclude = (fsPath: string) => {
+export const shouldExclude = (fsPath: string) => {
   const normalizedPath = fsPath.replace(/\\/g, "/");
 
   return getExcludedDirs().some(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,10 +1,11 @@
 import * as vscode from "vscode";
 import { formatBadgeFileSize, formatFileSize, getFileSize } from "./utils";
 import { onDidChangeFileDecorations } from "./eventEmitter";
+import { shouldExclude } from "./fileWatcher";
 
 export const provider = vscode.window.registerFileDecorationProvider({
   provideFileDecoration(uri) {
-    if (uri.scheme !== "file") return;
+    if (uri.scheme !== "file" || shouldExclude(uri.fsPath)) return;
     const fileSize = getFileSize(uri.fsPath);
     if (fileSize === null) return;
     return {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,9 +1,6 @@
 import * as vscode from "vscode";
 import { formatFileSize, getFileSize } from "./utils";
-
-export const statusBar = vscode.window.createStatusBarItem(
-  vscode.StatusBarAlignment.Left
-);
+import { shouldExclude } from "./fileWatcher";
 
 const getUri = () => {
   const activeEditor = vscode.window.activeTextEditor;
@@ -28,9 +25,31 @@ const getUri = () => {
   }
 };
 
+const getStatusBarConfig = () => {
+  const config = vscode.workspace.getConfiguration("fileSizeBadge");
+  const alignment = config.get<keyof typeof vscode.StatusBarAlignment>(
+    "statusBarAlignment",
+    "Left"
+  );
+  const priority = config.get<number>("statusBarPriority");
+
+  return [vscode.StatusBarAlignment[alignment], priority] as const;
+};
+
+// Using `let` instead of `const` because the status bar must be recreated when
+// alignment or priority change (these are immutable constructor parameters in VS Code's API).
+// A Proxy was considered but rejected for simplicity - this direct approach is clearer.
+export let statusBar = vscode.window.createStatusBarItem(
+  ...getStatusBarConfig()
+);
+
 export const updateStatusBar = () => {
   const uri = getUri();
   if (!uri || uri.scheme !== "file") {
+    statusBar.hide();
+    return;
+  }
+  if (shouldExclude(uri.fsPath)) {
     statusBar.hide();
     return;
   }
@@ -45,6 +64,12 @@ export const updateStatusBar = () => {
   statusBar.show();
 };
 
+export const recreateStatusBar = () => {
+  statusBar.dispose();
+  statusBar = vscode.window.createStatusBarItem(...getStatusBarConfig());
+  updateStatusBar();
+};
+
 export const updateStatusBarOnChangeActiveTextEditor =
   vscode.window.onDidChangeActiveTextEditor(updateStatusBar);
 
@@ -53,3 +78,13 @@ export const updateStatusBarOnChangeTabs =
 
 export const updateStatusBarOnSaveTextDocument =
   vscode.workspace.onDidSaveTextDocument(() => updateStatusBar());
+
+export const updateStatusBarOnChangeConfiguration =
+  vscode.workspace.onDidChangeConfiguration((e) => {
+    if (
+      e.affectsConfiguration("fileSizeBadge.statusBarAlignment") ||
+      e.affectsConfiguration("fileSizeBadge.statusBarPriority")
+    ) {
+      recreateStatusBar();
+    }
+  });


### PR DESCRIPTION
Adds configuration options to customize the position of the file size status bar item.

## New Configuration Options

- **`fileSizeBadge.statusBarAlignment`**: Choose `"Left"` or `"Right"` to control which side of the status bar the item appears on (default: `"Left"`)
- **`fileSizeBadge.statusBarPriority`**: Set a numeric priority to control positioning relative to other status bar items. Lower numbers appear more to the left. Leave empty (`null`) to let the IDE decide automatically (default: `null`)

## Implementation Details

- Status bar item is automatically recreated when alignment or priority settings change
- Configuration changes are detected via `onDidChangeConfiguration` event
- Updates documentation with new configuration options

Closes #4